### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/llama-cpp-low/Cargo.toml
+++ b/llama-cpp-low/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["llm"]
 description = "small server binary compile build from llama.cpp"
 readme = "README.md"
 exclude = ["llama.cpp/models/**", "llama.cpp/kompute/**"]
+repository = "https://github.com/blmarket/llm-daemon"
 
 [dependencies]
 

--- a/llm-daemon/Cargo.toml
+++ b/llm-daemon/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-only"
 keywords = ["llm"]
 description = "LLM as a daemon"
 readme = "README.md"
+repository = "https://github.com/blmarket/llm-daemon"
 
 [dependencies]
 llama_cpp_low = { version = "0.3.5", path = "../llama-cpp-low" }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.